### PR TITLE
delete UcliEvt.log before exit

### DIFF
--- a/check_aacraid
+++ b/check_aacraid
@@ -203,5 +203,6 @@ if __name__ == '__main__':
 		n = get_num_controllers()
 		for c in range(1,n+1):
 	    		print cmk_info(c)
+	    	os.remove("./UcliEvt.log")
 	else:
 		print "3 No_arcconf_Found - UNKNOWN (No arcconf binary Found or no Adaptec Controller present (remove check from local checks))"


### PR DESCRIPTION
A file named UcliEvt.log is created under the /lib/check_mk_agent/local directory (at least on Solaris), so the next time check_mk will perform an inventory, it will try to execute such file leading to an error.

Remove this log file upon script completion